### PR TITLE
Fixed a bug in the formation of the action value function for Policy Iteration

### DIFF
--- a/DP/Policy Iteration Solution.ipynb
+++ b/DP/Policy Iteration Solution.ipynb
@@ -120,7 +120,7 @@
     "            action_values = np.zeros(env.nA)\n",
     "            for a in range(env.nA):\n",
     "                for prob, next_state, reward, done in env.P[s][a]:\n",
-    "                    action_values[a] = prob * (reward + discount_factor * V[next_state])\n",
+    "                    action_values[a] += prob * (reward + discount_factor * V[next_state])\n",
     "            best_a = np.argmax(action_values)\n",
     "            \n",
     "            # Greedily update the policy\n",


### PR DESCRIPTION
Fixed a bug in Policy Iteration where action_values was formed from only the last next_state in env.P[s][a]. This has no impact when running on Gridworld since all transitions have P = 1; there is only one next_state for each state-action pair (deterministic). Nonetheless, this fix is strictly 'more correct' from a programming (and mathematical) perspective.