### PR TITLE
Update Continuous MountainCar Actor Critic Solution.ipynb

### DIFF
--- a/PolicyGradient/Continuous MountainCar Actor Critic Solution.ipynb
+++ b/PolicyGradient/Continuous MountainCar Actor Critic Solution.ipynb
@@ -152,7 +152,7 @@
     "            self.sigma = tf.squeeze(self.sigma)\n",
     "            self.sigma = tf.nn.softplus(self.sigma) + 1e-5\n",
     "            self.normal_dist = tf.contrib.distributions.Normal(self.mu, self.sigma)\n",
-    "            self.action = self.normal_dist.sample_n(1)\n",
+    "            self.action = self.normal_dist._sample_n(1)\n",
     "            self.action = tf.clip_by_value(self.action, env.action_space.low[0], env.action_space.high[0])\n",
     "\n",
     "            # Loss and train op\n",


### PR DESCRIPTION
it seems in tensorflow 1.o+, `sample_n` method doesn't exist. changed to `_sample_n`. And `sample` is fine too.