### PR TITLE
fix markdown links with spaces

### DIFF
--- a/DP/README.md
+++ b/DP/README.md
@@ -34,13 +34,13 @@
 ### Exercises
 
 - Implement Policy Evaluation in Python (Gridworld)
-  - [Exercise](Policy Evaluation.ipynb)
-  - [Solution](Policy Evaluation Solution.ipynb)
+  - [Exercise](Policy%20Evaluation.ipynb)
+  - [Solution](Policy%20Evaluation Solution.ipynb)
 
 - Implement Policy Iteration in Python (Gridworld)
-  - [Exercise](Policy Iteration.ipynb)
-  - [Solution](Policy Iteration Solution.ipynb)
+  - [Exercise](Policy%20Iteration.ipynb)
+  - [Solution](Policy%20Iteration%20Solution.ipynb)
 
 - Implement Value Iteration in Python (Gridworld)
-  - [Exercise](Value Iteration.ipynb)
-  - [Solution](Value Iteration Solution.ipynb)
+  - [Exercise](Value%20Iteration.ipynb)
+  - [Solution](Value%20Iteration%20Solution.ipynb)


### PR DESCRIPTION
space literals not allowed in markdown links