### PR TITLE
activation fn from relu to None

### DIFF
--- a/DQN/Deep Q Learning Solution.ipynb
+++ b/DQN/Deep Q Learning Solution.ipynb
@@ -30,7 +30,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "env = gym.envs.make(\"Breakout-v0\")"
@@ -39,7 +41,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Atari Actions: 0 (noop), 1 (fire), 2 (left) and 3 (right) are valid actions\n",
@@ -83,7 +87,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class Estimator():\n",
@@ -132,7 +138,7 @@
     "        # Fully connected layers\n",
     "        flattened = tf.contrib.layers.flatten(conv3)\n",
     "        fc1 = tf.contrib.layers.fully_connected(flattened, 512)\n",
-    "        self.predictions = tf.contrib.layers.fully_connected(fc1, len(VALID_ACTIONS))\n",
+    "        self.predictions = tf.contrib.layers.fully_connected(fc1, len(VALID_ACTIONS), activation_fn=None)\n",
     "\n",
     "        # Get the predictions for the chosen actions only\n",
     "        gather_indices = tf.range(batch_size) * tf.shape(self.predictions)[1] + self.actions_pl\n",
@@ -193,7 +199,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# For Testing....\n",
@@ -295,7 +303,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def deep_q_learning(sess,\n",
@@ -494,7 +504,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tf.reset_default_graph()\n",
@@ -569,7 +581,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/DQN/Deep Q Learning.ipynb
+++ b/DQN/Deep Q Learning.ipynb
@@ -136,7 +136,7 @@
     "        # Fully connected layers\n",
     "        flattened = tf.contrib.layers.flatten(conv3)\n",
     "        fc1 = tf.contrib.layers.fully_connected(flattened, 512)\n",
-    "        self.predictions = tf.contrib.layers.fully_connected(fc1, len(VALID_ACTIONS))\n",
+    "        self.predictions = tf.contrib.layers.fully_connected(fc1, len(VALID_ACTIONS), activation_fn=None)\n",
     "\n",
     "        # Get the predictions for the chosen actions only\n",
     "        gather_indices = tf.range(batch_size) * tf.shape(self.predictions)[1] + self.actions_pl\n",
@@ -526,7 +526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
At `self.predictions = tf.contrib.layers.fully_connected(fc1, len(VALID_ACTIONS))`
Default activation_fn will be Relu, which prevents giving negative value predictions, critical at games like Pong where there are negative state values.
