### PR TITLE
bind worker within lambda to avoid running worker twice

### DIFF
--- a/PolicyGradient/a3c/train.py
+++ b/PolicyGradient/a3c/train.py
@@ -125,7 +125,7 @@ with tf.Session() as sess:
   # Start worker threads
   worker_threads = []
   for worker in workers:
-    worker_fn = lambda: worker.run(sess, coord, FLAGS.t_max)
+    worker_fn = lambda worker=worker: worker.run(sess, coord, FLAGS.t_max)
     t = threading.Thread(target=worker_fn)
     t.start()
     worker_threads.append(t)


### PR DESCRIPTION
Bind worker within the lambda function otherwise the same worker object's 'run' method may be called twice .