### PR TITLE
worker name scope should have trailing slash

### DIFF
--- a/PolicyGradient/a3c/worker.py
+++ b/PolicyGradient/a3c/worker.py
@@ -85,7 +85,7 @@ class Worker(object):
     # Op to copy params from global policy/valuenets
     self.copy_params_op = make_copy_params_op(
       tf.contrib.slim.get_variables(scope="global", collection=tf.GraphKeys.TRAINABLE_VARIABLES),
-      tf.contrib.slim.get_variables(scope=self.name, collection=tf.GraphKeys.TRAINABLE_VARIABLES))
+      tf.contrib.slim.get_variables(scope=self.name+'/', collection=tf.GraphKeys.TRAINABLE_VARIABLES))
 
     self.vnet_train_op = make_train_op(self.value_net, self.global_value_net)
     self.pnet_train_op = make_train_op(self.policy_net, self.global_policy_net)


### PR DESCRIPTION
Conflicts in scope can arise if trailing slash is not provided and there are greater than 10 threads.
For example, with 16 threads, scope="worker_1" will include "worker_1", "worker_10", "worker_11", and so on till "worker_15". Adding the slash makes sure scope ends with worker name.