### PR TITLE
correction for state processor output shape

### DIFF
--- a/DQN/Deep Q Learning.ipynb
+++ b/DQN/Deep Q Learning.ipynb
@@ -74,7 +74,7 @@
     "            state: A [210, 160, 3] Atari RGB State\n",
     "\n",
     "        Returns:\n",
-    "            A processed [84, 84, 1] state representing grayscale values.\n",
+    "            A processed [84, 84] state representing grayscale values.\n",
     "        \"\"\"\n",
     "        return sess.run(self.output, { self.input_state: state })"
    ]


### PR DESCRIPTION
StateProcessor actually outputs a rank 2 tensor with a shape [84, 84]