### PR TITLE
added link to CS885

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Classes:
 - [David Silver's Reinforcement Learning Course (UCL, 2015)](http://www0.cs.ucl.ac.uk/staff/d.silver/web/Teaching.html)
 - [CS294 - Deep Reinforcement Learning (Berkeley, Fall 2015)](http://rll.berkeley.edu/deeprlcourse/)
 - [CS 8803 - Reinforcement Learning (Georgia Tech)](https://www.udacity.com/course/reinforcement-learning--ud600)
+- [CS885 - Reinforcement Learning (UWaterloo), Spring 2018](https://cs.uwaterloo.ca/~ppoupart/teaching/cs885-spring18/)
 
 Talks/Tutorials:
 


### PR DESCRIPTION
Added CS885 Reinforcement Learning course from University of Waterloo. One of the most comprehensive RL courses.