### PR TITLE
Modify "v (list) : state value function" to "V"

### DIFF
--- a/DP/Policy Evaluation Solution.ipynb
+++ b/DP/Policy Evaluation Solution.ipynb
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "random_policy = np.ones([env.nS, env.nA]) / env.nA\n",
-    "v = policy_eval(random_policy, env)"
+    "V = policy_eval(random_policy, env)"
    ]
   },
   {
@@ -105,11 +105,11 @@
    ],
    "source": [
     "print(\"Value Function:\")\n",
-    "print(v)\n",
+    "print(V)\n",
     "print(\"\")\n",
     "\n",
     "print(\"Reshaped Grid Value Function:\")\n",
-    "print(v.reshape(env.shape))\n",
+    "print(V.reshape(env.shape))\n",
     "print(\"\")"
    ]
   },
@@ -120,7 +120,7 @@
    "outputs": [],
    "source": [
     "# Test: Make sure the evaluated policy is what we expected\n",
-    "expected_v = np.array([0, -14, -20, -22, -14, -18, -20, -20, -20, -20, -18, -14, -22, -20, -14, 0])\n",
+    "expected_V = np.array([0, -14, -20, -22, -14, -18, -20, -20, -20, -20, -18, -14, -22, -20, -14, 0])\n",
     "np.testing.assert_array_almost_equal(v, expected_v, decimal=2)"
    ]
   },


### PR DESCRIPTION
It would better express list as uppercase, since it is well-known nomenclature in large areas of mathematics, computer sciences and most of papers.
Also, in the function definition, state value function is defined is uppercase "V", not "v". Need to unify the variable names.

If changed, I'll change all corresponding .ipynb codes in the DP directory.